### PR TITLE
Add support for chrono NaiveDate & NaiveDateTime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,5 @@ categories = ["encoding", "text-processing"]
 travis-ci = { repository = "outersky/simple_excel_writer" }
 
 [dependencies]
+chrono = { version = "0.4", optional = true, default-features = false }
 zip = "0.5.5" 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,9 @@
 
 extern crate zip;
 
+#[cfg(feature = "chrono")]
+extern crate chrono;
+
 pub use sheet::*;
 pub use workbook::*;
 

--- a/src/workbook.rs
+++ b/src/workbook.rs
@@ -421,6 +421,7 @@ impl Workbook {
     <cellXfs count="2">
         <xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0" applyNumberFormat="1"/>
         <xf numFmtId="14" fontId="0" fillId="0" borderId="0" xfId="0" applyNumberFormat="1"/>
+        <xf numFmtId="22" fontId="0" fillId="0" borderId="0" xfId="0" applyNumberFormat="1"/>
     </cellXfs>
     <cellStyles count="1">
         <cellStyle name="Normal" xfId="0" builtinId="0"/>

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -40,7 +40,15 @@ fn creates_and_saves_an_excel_sheet_driver(filename: Option<&str>) -> Option<Vec
 
     wb.write_sheet(&mut ws, |sw| {
         sw.append_row(row!["Name", "Title", "Success"]).unwrap();
-        sw.append_row(row!["Mary", "This", true])
+        sw.append_row(row!["Mary", "This", true]).unwrap();
+
+        #[cfg(feature = "chrono")]
+        sw.append_row(row![
+            chrono::NaiveDate::from_ymd(2020, 10, 15).and_hms(18, 27, 11),
+            chrono::NaiveDate::from_ymd(2020, 10, 16)
+        ])
+        .unwrap();
+        Ok(())
     })
     .expect("Write excel error!");
 


### PR DESCRIPTION
This introduces the ability to convert [`chrono::NaiveDate`](https://docs.rs/chrono/0.4.19/chrono/naive/struct.NaiveDate.html) and [`chrono::NaiveDateTime`](https://docs.rs/chrono/0.4.19/chrono/naive/struct.NaiveDateTime.html) to `CellValue`.

`chrono` is used as optional dependency, therefore I am pretty sure this could be introduced as a patch version bump.

**EDIT**: I decided use different representation for numbers, dates and date times. In this way, now it is possible to use an appropriate style for both dates and date times.