### PR TITLE
A bunch of small tweaks, including fixed wrong `Sheet` name truncation.

### DIFF
--- a/src/sheet.rs
+++ b/src/sheet.rs
@@ -84,7 +84,7 @@ impl ToCellValue for f64 {
 
 impl ToCellValue for String {
     fn to_cell_value(&self) -> CellValue {
-        if self.starts_with("=") {
+        if self.starts_with('=') {
             return CellValue::Formula(self.to_owned());
         }
         CellValue::String(self.to_owned())
@@ -93,10 +93,10 @@ impl ToCellValue for String {
 
 impl<'a> ToCellValue for &'a str {
     fn to_cell_value(&self) -> CellValue {
-        if self.starts_with("=") {
-            return CellValue::Formula(self.to_owned().to_string());
+        if self.starts_with('=') {
+            return CellValue::Formula(self.to_string());
         }
-        CellValue::String(self.to_owned().to_owned())
+        CellValue::String(self.to_string())
     }
 }
 

--- a/src/sheet.rs
+++ b/src/sheet.rs
@@ -258,10 +258,7 @@ pub fn column_letter(column_index: usize) -> String {
 }
 
 pub fn validate_name(name: &str) -> String {
-    let mut name = escape_xml(name);
-    let boundary = if name.is_char_boundary(30) { 30 } else { 29 };
-    name.truncate(boundary);
-    name.replace("/", "-")
+    escape_xml(name).replace("/", "-")
 }
 
 impl Sheet {

--- a/src/workbook.rs
+++ b/src/workbook.rs
@@ -118,7 +118,7 @@ impl Workbook {
             let mut writer = zip::ZipWriter::new(&mut cursor);
             for archive_file in self.archive_files.iter() {
                 let options = zip::write::FileOptions::default();
-                writer.start_file_from_path(&archive_file.name, options)?;
+                writer.start_file(archive_file.name.to_string_lossy(), options)?;
                 writer.write_all(&archive_file.data)?;
             }
 

--- a/src/workbook.rs
+++ b/src/workbook.rs
@@ -102,11 +102,21 @@ impl Workbook {
     pub fn create_sheet(&mut self, sheet_name: &str) -> Sheet {
         self.max_sheet_index += 1;
 
+        let validated_name = crate::validate_name(sheet_name);
+
         self.sheets.push(SheetRef {
             id: self.max_sheet_index,
-            name: crate::validate_name(sheet_name), //sheet_name.to_owned(),
+            name: validated_name.clone(),
         });
-        Sheet::new(self.max_sheet_index, sheet_name)
+
+        // `Sheet` has a private field, so we can't just construct it here with needed values.
+        // So we must create default sheet first and then mutate it.
+        let mut sheet = Sheet::default();
+
+        sheet.id = self.max_sheet_index;
+        sheet.name = validated_name;
+
+        sheet
     }
 
     pub fn close(&mut self) -> Result<Option<Vec<u8>>> {

--- a/src/workbook.rs
+++ b/src/workbook.rs
@@ -17,6 +17,7 @@ pub struct Workbook {
     shared_strings: SharedStrings,
     sheets: Vec<SheetRef>,
     calc_chain: Vec<(String, usize)>,
+    saved: bool,
 }
 
 #[derive(Default, Clone)]
@@ -75,7 +76,9 @@ impl Workbook {
             archive_files: Vec::new(),
             max_sheet_index: 0,
             shared_strings: SharedStrings::new(),
-            ..Default::default()
+            sheets: Vec::new(),
+            calc_chain: Vec::new(),
+            saved: false,
         }
     }
     /// Creates a workbook not using shared strings
@@ -85,7 +88,9 @@ impl Workbook {
             archive_files: Vec::new(),
             max_sheet_index: 0,
             shared_strings: SharedStrings::new_unused(),
-            ..Default::default()
+            sheets: Vec::new(),
+            calc_chain: Vec::new(),
+            saved: false,
         }
     }
 
@@ -95,7 +100,9 @@ impl Workbook {
             archive_files: Vec::new(),
             max_sheet_index: 0,
             shared_strings: SharedStrings::new_unused(),
-            ..Default::default()
+            sheets: Vec::new(),
+            calc_chain: Vec::new(),
+            saved: false,
         }
     }
 
@@ -138,6 +145,7 @@ impl Workbook {
         if let Some(xlsx_file) = &self.xlsx_file {
             let mut file = File::create(xlsx_file).unwrap();
             file.write_all(&buf)?;
+            self.saved = true;
 
             Ok(None)
         } else {
@@ -901,4 +909,12 @@ impl Workbook {
             writer.write_all(xml.as_bytes())
         }
     */
+}
+
+impl Drop for Workbook {
+    fn drop(&mut self) {
+        if !self.saved && self.xlsx_file.is_some() {
+            self.close().expect("Workbook saving error");
+        }
+    }
 }


### PR DESCRIPTION
* Changed formula detection in `ToCellValue` implementations;
* Removed double allocation in `ToCellValue` implementation for `&str`;
* Fixed deprecated warning when using `ZipWriter::start_file_from_path`;
* Removed double `Sheet` name validation while creating new sheet in a workbook;
* Changed `Sheet` name truncation. it seem like original algorithm is invalid. See #bdc4548  comment for more details.
* RAII support for Workbook.