### PR TITLE
fix: remove unnecessary transitive bzip2 dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,5 @@ travis-ci = { repository = "outersky/simple_excel_writer" }
 
 [dependencies]
 chrono = { version = "0.4", optional = true, default-features = false }
-zip = "0.5.5" 
+# omit bzip2 feature
+zip = {version = "0.5.5", default-features = false, features = ["deflate", "time"] }


### PR DESCRIPTION
The default_features of the zip module that simple_excel_writer depends on include bzip2 support, which adds unnecessary extra compile time and bloat and, maybe more problematically, also a C dependency. 

Since to the best of my knowledge Office applications only support deflate compression anyway, disabling bzip2 support in zip's features seems to be the way to go.