### PR TITLE
remove "time" feature from zip

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ travis-ci = { repository = "outersky/simple_excel_writer" }
 [dependencies]
 chrono = { version = "0.4.19", optional = true, default-features = false }
 # omit bzip2 feature
-zip = {version = "0.5.13", default-features = false, features = ["deflate", "time"] }
+zip = {version = "0.5.13", default-features = false, features = ["deflate"] }


### PR DESCRIPTION
when enabling the "time" feature, a syscallcall will be made in order to construct the `last_modified_time` of the zip file

this is unavailable in WASM environments, and will cause a runtime error when one attempts to construct a zip file in this environment

closes #25 