### PR TITLE
Add xf_format writing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # simple_excel_writer
+
 simple excel writer in Rust
 
-[![Build Status](https://travis-ci.org/outersky/simple_excel_writer.png?branch=master)](https://travis-ci.org/outersky/simple_excel_writer) 
+[![Build Status](https://travis-ci.org/outersky/simple_excel_writer.png?branch=master)](https://travis-ci.org/outersky/simple_excel_writer)
 [Documentation](https://docs.rs/simple_excel_writer/)
 
 ## Example
@@ -60,10 +61,12 @@ fn main() {
 ## Change Log
 
 ### 0.2.0 (2022-03-11)
+
 - support WASM !
 
 ### 0.1.9 (2021-10-28)
-- support formula 
+
+- support formula
 - support NaiveDate & NaiveDateTime
 - format dates and date times
 - Sheet name validation
@@ -72,6 +75,7 @@ fn main() {
 many thanks to all contributors !
 
 #### 0.1.7 (2020-04-29)
+
 - support create-in-memory mode, thanks to Maxburke.
 
 ```
@@ -84,23 +88,30 @@ the completed XLSX file contents when closed.
 ```
 
 #### 0.1.6 (2020-04-06)
+
 - support shared strings between worksheets, thanks to Mikael Edlund.
 
 #### 0.1.5 (2019-03-21)
+
 - support Windows platform, thanks to Carl Fredrik Samson.
 
 #### 0.1.4 (2017-03-24)
+
 - escape xml characters.
 
 #### 0.1.3 (2017-01-03)
+
 - support 26+ columns .
 - fix column width bug.
 
 #### 0.1.2 (2017-01-02)
+
 - support multiple sheets
 
 #### 0.1 (2017-01-01)
+
 - generate the basic xlsx file
 
 ## License
+
 Apache-2.0

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -34,17 +34,26 @@ fn main() {
     })
     .expect("write excel error!");
 
-    let euro_fmt_idx = wb.add_cust_number_format("\"€\"#,##0.00".to_string());
-    let weight_fmt_idx = wb.add_cust_number_format("#,##0.0\" KG\"".to_string());
+    let euro_fmt_idx = wb.add_number_format("\"€\"#,##0.00".to_string());
+    let weight_fmt_idx = wb.add_number_format("#,##0.0\" KG\"".to_string());
+    let euro_fmt = wb.add_cell_xf(CellXf {
+        num_fmt: Some(euro_fmt_idx),
+        ..Default::default()
+    });
+    let weight_fmt = wb.add_cell_xf(CellXf {
+        num_fmt: Some(weight_fmt_idx),
+        ..Default::default()
+    });
     let mut sheet_num_fmt = wb.create_sheet("SheetNumFormatted");
     sheet_num_fmt.add_column(Column { width: 30.0 });
     sheet_num_fmt.add_column(Column { width: 30.0 });
     wb.write_sheet(&mut sheet_num_fmt, |sheet_writer| {
         let sw = sheet_writer;
         sw.append_row(row!["Weight", "Price"])?;
-        sw.append_row(row![(700.5, weight_fmt_idx), (12045.99, euro_fmt_idx)])?;
-        sw.append_row(row![(1525.0, weight_fmt_idx), (25999.00, euro_fmt_idx)])
-    }).expect("write excel error!");
+        sw.append_row(row![(700.5, weight_fmt), (12045.99, euro_fmt)])?;
+        sw.append_row(row![(1525.0, weight_fmt), (25999.00, euro_fmt)])
+    })
+    .expect("write excel error!");
 
     wb.close().expect("close excel error!");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,16 +42,18 @@
 //!         sw.append_row(row!["Amy", "Manager", true])
 //!     }).expect("write excel error!");
 //!
-//!     let euro_fmt_idx = wb.add_cust_number_format("\"€\"#,##0.00".to_string());
-//!     let weight_fmt_idx = wb.add_cust_number_format("#,##0.0\" KG\"".to_string());
+//!     let euro_fmt_idx = wb.add_number_format("\"€\"#,##0.00".to_string());
+//!     let weight_fmt_idx = wb.add_number_format("#,##0.0\" KG\"".to_string());
+//!     let euro_fmt = wb.add_cell_xf(CellXf { num_fmt: Some(euro_fmt_idx), ..Default::default() });
+//!     let weight_fmt = wb.add_cell_xf(CellXf { num_fmt: Some(weight_fmt_idx), ..Default::default() });
 //!     let mut sheet_num_fmt = wb.create_sheet("SheetNumFormatted");
 //!     sheet_num_fmt.add_column(Column { width: 30.0 });
 //!     sheet_num_fmt.add_column(Column { width: 30.0 });
 //!     wb.write_sheet(&mut sheet_num_fmt, |sheet_writer| {
 //!         let sw = sheet_writer;
 //!         sw.append_row(row!["Weight", "Price"])?;
-//!         sw.append_row(row![(700.5, weight_fmt_idx), (12045.99, euro_fmt_idx)])?;
-//!         sw.append_row(row![(1525.0, weight_fmt_idx), (25999.00, euro_fmt_idx)])
+//!         sw.append_row(row![(700.5, weight_fmt), (12045.99, euro_fmt)])?;
+//!         sw.append_row(row![(1525.0, weight_fmt), (25999.00, euro_fmt)])
 //!     }).expect("write excel error!");
 //!
 //!     wb.close().expect("close excel error!");

--- a/src/sheet.rs
+++ b/src/sheet.rs
@@ -191,7 +191,7 @@ impl ToCellData for f64 {
 impl ToCellData for String {
     fn to_cell_data(&self) -> CellData {
         if self.starts_with('=') {
-            return CellValue::Formula(self.to_owned()).into();
+            return CellValue::Formula((&self[1..]).to_string()).into();
         }
         CellValue::String(self.to_owned()).into()
     }
@@ -200,7 +200,7 @@ impl ToCellData for String {
 impl<'a> ToCellData for &'a str {
     fn to_cell_data(&self) -> CellData {
         if self.starts_with('=') {
-            return CellValue::Formula(self.to_string()).into();
+            return CellValue::Formula((&self[1..]).to_string()).into();
         }
         CellValue::String(self.to_string()).into()
     }

--- a/src/sheet.rs
+++ b/src/sheet.rs
@@ -1,4 +1,4 @@
-use std::io::{Error, ErrorKind, Result, Write};
+use std::{io::{Error, ErrorKind, Result, Write}, iter::FromIterator};
 
 #[macro_export]
 macro_rules! row {
@@ -25,12 +25,15 @@ pub struct AutoFilter {
     pub start_col: String,
     pub end_col: String,
     pub start_row: usize,
-    pub end_row: usize
+    pub end_row: usize,
 }
 
 impl ToString for AutoFilter {
     fn to_string(&self) -> String {
-        format!("{}{}:{}{}", self.start_col, self.start_row, self.end_col, self.end_row)
+        format!(
+            "{}{}:{}{}",
+            self.start_col, self.start_row, self.end_col, self.end_row
+        )
     }
 }
 
@@ -42,7 +45,7 @@ pub struct Sheet {
     max_row_index: usize,
     pub calc_chain: Vec<String>,
     pub merged_cells: Vec<MergedCell>,
-    pub auto_filter: Option<AutoFilter>
+    pub auto_filter: Option<AutoFilter>,
 }
 
 #[derive(Default)]
@@ -55,7 +58,7 @@ pub struct Row {
 
 pub struct Cell {
     pub column_index: usize,
-    pub value: CellValue,
+    pub value: CellData,
 }
 
 pub struct MergedCell {
@@ -68,10 +71,69 @@ pub struct Column {
 }
 
 #[derive(Clone)]
+pub struct CellData {
+    pub value: CellValue,
+    pub xf_format: Option<XfFormat>,
+}
+impl From<CellValue> for CellData {
+    fn from(value: CellValue) -> Self {
+        CellData {
+            value,
+            xf_format: None,
+        }
+    }
+}
+impl CellData {
+    pub fn with_xf_format(mut self, xf_format: XfFormat) -> Self {
+        self.xf_format = Some(xf_format);
+        self
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct XfFormat(pub(crate) u16);
+impl XfFormat {
+    pub fn value(&self) -> u16 {
+        self.0
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct NumberFormat(pub(crate) u16);
+impl NumberFormat {
+    pub fn value(&self) -> u16 {
+        self.0
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct Border(pub(crate) u16);
+impl Border {
+    pub fn value(&self) -> u16 {
+        self.0
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct Font(pub(crate) u16);
+impl Font {
+    pub fn value(&self) -> u16 {
+        self.0
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct Fill(pub(crate) u16);
+impl Fill {
+    pub fn value(&self) -> u16 {
+        self.0
+    }
+}
+
+#[derive(Clone)]
 pub enum CellValue {
     Bool(bool),
     Number(f64),
-    NumberFormatted((f64, u16)),
     #[cfg(feature = "chrono")]
     Date(f64),
     #[cfg(feature = "chrono")]
@@ -91,71 +153,94 @@ where
     shared_strings: &'b mut crate::SharedStrings,
 }
 
-pub trait ToCellValue {
-    fn to_cell_value(&self) -> CellValue;
+pub trait ToCellData {
+    fn to_cell_data(&self) -> CellData;
 }
 
-impl ToCellValue for bool {
-    fn to_cell_value(&self) -> CellValue {
-        CellValue::Bool(self.to_owned())
+impl ToCellData for CellData {
+    fn to_cell_data(&self) -> CellData {
+        self.clone()
     }
 }
 
-impl ToCellValue for (f64, u16) {
-    fn to_cell_value(&self) -> CellValue {
-        CellValue::NumberFormatted(self.to_owned())
+impl ToCellData for CellValue {
+    fn to_cell_data(&self) -> CellData {
+        self.clone().into()
     }
 }
 
-impl ToCellValue for f64 {
-    fn to_cell_value(&self) -> CellValue {
-        CellValue::Number(self.to_owned())
+impl ToCellData for bool {
+    fn to_cell_data(&self) -> CellData {
+        CellValue::Bool(self.to_owned()).into()
     }
 }
 
-impl ToCellValue for String {
-    fn to_cell_value(&self) -> CellValue {
+impl ToCellData for (f64, XfFormat) {
+    fn to_cell_data(&self) -> CellData {
+        let (number, format) = self;
+        CellData::from(CellValue::Number(*number)).with_xf_format(*format)
+    }
+}
+
+impl ToCellData for f64 {
+    fn to_cell_data(&self) -> CellData {
+        CellValue::Number(self.to_owned()).into()
+    }
+}
+
+impl ToCellData for String {
+    fn to_cell_data(&self) -> CellData {
         if self.starts_with('=') {
-            return CellValue::Formula(self.to_owned());
+            return CellValue::Formula(self.to_owned()).into();
         }
-        CellValue::String(self.to_owned())
+        CellValue::String(self.to_owned()).into()
     }
 }
 
-impl<'a> ToCellValue for &'a str {
-    fn to_cell_value(&self) -> CellValue {
+impl<'a> ToCellData for &'a str {
+    fn to_cell_data(&self) -> CellData {
         if self.starts_with('=') {
-            return CellValue::Formula(self.to_string());
+            return CellValue::Formula(self.to_string()).into();
         }
-        CellValue::String(self.to_string())
+        CellValue::String(self.to_string()).into()
     }
 }
 
-impl ToCellValue for () {
-    fn to_cell_value(&self) -> CellValue {
-        CellValue::Blank(1)
+impl ToCellData for () {
+    fn to_cell_data(&self) -> CellData {
+        CellValue::Blank(1).into()
     }
 }
 
 #[cfg(feature = "chrono")]
-impl ToCellValue for chrono::NaiveDateTime {
-    fn to_cell_value(&self) -> CellValue {
+impl ToCellData for chrono::NaiveDateTime {
+    fn to_cell_data(&self) -> CellData {
         let seconds = self.timestamp();
         let nanos = f64::from(self.timestamp_subsec_nanos()) * 1e-9;
         let unix_seconds = seconds as f64 + nanos;
         let unix_days = unix_seconds / 86400.;
-        CellValue::Datetime(unix_days + 25569.)
+        CellValue::Datetime(unix_days + 25569.).into()
     }
 }
 
 #[cfg(feature = "chrono")]
-impl ToCellValue for chrono::NaiveDate {
-    fn to_cell_value(&self) -> CellValue {
+impl ToCellData for chrono::NaiveDate {
+    fn to_cell_data(&self) -> CellData {
         use chrono::Datelike;
         const UNIX_EPOCH_DAY: i32 = 719_163;
 
         let unix_days: f64 = (self.num_days_from_ce() - UNIX_EPOCH_DAY).into();
-        CellValue::Date(unix_days + 25569.)
+        CellValue::Date(unix_days + 25569.).into()
+    }
+}
+
+impl<A: ToCellData> FromIterator<A> for Row {
+    fn from_iter<T: IntoIterator<Item = A>>(iter: T) -> Self {
+        let mut row = Row::new();
+        for val in iter {
+            row.add_cell(val)
+        }
+        row
     }
 }
 
@@ -166,31 +251,18 @@ impl Row {
         }
     }
 
-    pub fn from_iter<T>(iter: impl Iterator<Item = T>) -> Row
-    where
-        T: ToCellValue + Sized,
-    {
-        let mut row = Row::new();
-
-        for val in iter {
-            row.add_cell(val)
-        }
-
-        row
-    }
-
     pub fn add_cell<T>(&mut self, value: T)
     where
-        T: ToCellValue + Sized,
+        T: ToCellData + Sized,
     {
-        let value = value.to_cell_value();
-        match &value {
+        let value = &value.to_cell_data();
+        match &value.value {
             CellValue::Formula(f) => {
                 self.calc_chain.push(f.to_owned());
                 self.max_col_index += 1;
                 self.cells.push(Cell {
                     column_index: self.max_col_index,
-                    value,
+                    value: value.clone(),
                 })
             }
             CellValue::Blank(cols) => self.max_col_index += cols,
@@ -198,7 +270,7 @@ impl Row {
                 self.max_col_index += 1;
                 self.cells.push(Cell {
                     column_index: self.max_col_index,
-                    value,
+                    value: value.clone(),
                 })
             }
         }
@@ -236,7 +308,7 @@ impl Row {
             return self;
         }
         for cell in self.cells.iter_mut() {
-            cell.value = match &cell.value {
+            cell.value.value = match &cell.value.value {
                 CellValue::String(val) => shared.register(&escape_xml(val)),
                 x => x.to_owned(),
             };
@@ -245,43 +317,40 @@ impl Row {
     }
 }
 
-impl ToCellValue for CellValue {
-    fn to_cell_value(&self) -> CellValue {
-        self.clone()
-    }
-}
-
-fn write_value(cv: &CellValue, ref_id: String, writer: &mut dyn Write) -> Result<()> {
-    match cv {
+fn write_value(cv: &CellData, ref_id: String, writer: &mut dyn Write) -> Result<()> {
+    let cell_style = cv
+        .xf_format
+        .map(|XfFormat(xf_format)| format!(" s=\"{xf_format}\""))
+        .unwrap_or_default();
+    match &cv.value {
         CellValue::Bool(b) => {
             let v = if *b { 1 } else { 0 };
-            let s = format!("<c r=\"{}\" t=\"b\"><v>{}</v></c>", ref_id, v);
+            let s = format!("<c r=\"{}\" t=\"b\"{cell_style}><v>{}</v></c>", ref_id, v);
             writer.write_all(s.as_bytes())?;
         }
-        &CellValue::Number(num) => write_number(&ref_id, num, None, writer)?,
-        &CellValue::NumberFormatted(num) => write_number(&ref_id, num.0, Some(num.1), writer)?,
+        &CellValue::Number(num) => write_number(&ref_id, num, cv.xf_format, writer)?,
         #[cfg(feature = "chrono")]
-        &CellValue::Date(num) => write_number(&ref_id, num, Some(1), writer)?,
+        &CellValue::Date(num) => write_number(&ref_id, num, Some(XfFormat(1)), writer)?,
         #[cfg(feature = "chrono")]
-        &CellValue::Datetime(num) => write_number(&ref_id, num, Some(2), writer)?,
+        &CellValue::Datetime(num) => write_number(&ref_id, num, Some(XfFormat(2)), writer)?,
         CellValue::String(ref s) => {
             let s = format!(
-                "<c r=\"{}\" t=\"str\"><v>{}</v></c>",
+                "<c r=\"{}\" t=\"str\"{cell_style}><v>{}</v></c>",
                 ref_id,
-                escape_xml(&s)
+                escape_xml(s)
             );
             writer.write_all(s.as_bytes())?;
         }
         CellValue::Formula(ref s) => {
             let s = format!(
-                "<c r=\"{}\" t=\"str\"><f>{}</f></c>",
+                "<c r=\"{}\" t=\"str\"{cell_style}><f>{}</f></c>",
                 ref_id,
-                escape_xml(&s)
+                escape_xml(s)
             );
             writer.write_all(s.as_bytes())?;
         }
         CellValue::SharedString(ref s) => {
-            let s = format!("<c r=\"{}\" t=\"s\"><v>{}</v></c>", ref_id, s);
+            let s = format!("<c r=\"{}\" t=\"s\"{cell_style}><v>{}</v></c>", ref_id, s);
             writer.write_all(s.as_bytes())?;
         }
         CellValue::Blank(_) => {}
@@ -292,25 +361,22 @@ fn write_value(cv: &CellValue, ref_id: String, writer: &mut dyn Write) -> Result
 fn write_number(
     ref_id: &str,
     value: f64,
-    style: Option<u16>,
+    style: Option<XfFormat>,
     writer: &mut dyn Write,
 ) -> Result<()> {
-    match style {
-        Some(style) => write!(
-            writer,
-            r#"<c r="{}" s="{}"><v>{}</v></c>"#,
-            ref_id, style, value
-        ),
-        None => write!(writer, r#"<c r="{}"><v>{}</v></c>"#, ref_id, value),
+    write!(writer, r#"<c r="{ref_id}""#)?;
+    if let Some(XfFormat(format)) = style {
+        write!(writer, r#" s="{format}""#)?;
     }
+    write!(writer, r#"><v>{value}</v></c>"#)
 }
 
 pub fn escape_xml(str: &str) -> String {
-    let str = str.replace("&", "&amp;");
-    let str = str.replace("<", "&lt;");
-    let str = str.replace(">", "&gt;");
-    let str = str.replace("'", "&apos;");
-    str.replace("\"", "&quot;")
+    let str = str.replace('&', "&amp;");
+    let str = str.replace('<', "&lt;");
+    let str = str.replace('>', "&gt;");
+    let str = str.replace('\'', "&apos;");
+    str.replace('\"', "&quot;")
 }
 
 impl Cell {
@@ -352,12 +418,11 @@ pub fn column_letter(column_index: usize) -> String {
 
     let result = result.into_iter().rev();
 
-    use std::iter::FromIterator;
     String::from_iter(result)
 }
 
 pub fn validate_name(name: &str) -> String {
-    escape_xml(name).replace("/", "-")
+    escape_xml(name).replace('/', "-")
 }
 
 impl Sheet {
@@ -373,11 +438,20 @@ impl Sheet {
     /// The arguments are used to construct the range of columns and rows used by the "AutoFilter"
     /// feature. For example: Column 1, Row 1 to Column 2, Row 2 will create the range "A1:B2".
     /// If invalid parameters are provided, the "AutoFilter" is not created.
-    pub fn add_auto_filter(&mut self, start_col: usize, end_col: usize, start_row: usize, end_row: usize) {
+    pub fn add_auto_filter(
+        &mut self,
+        start_col: usize,
+        end_col: usize,
+        start_row: usize,
+        end_row: usize,
+    ) {
         if start_col > 0 && start_row > 0 && start_col <= end_col && start_row <= end_row {
-            self.auto_filter = Some(AutoFilter{ start_col: column_letter(start_col),
-                                                end_col: column_letter(end_col),
-                                                start_row, end_row });
+            self.auto_filter = Some(AutoFilter {
+                start_col: column_letter(start_col),
+                end_col: column_letter(end_col),
+                start_row,
+                end_row,
+            });
         }
     }
 
@@ -448,7 +522,13 @@ impl Sheet {
 
     fn write_data_end(&self, writer: &mut dyn Write) -> Result<()> {
         if let Some(auto_filter) = &self.auto_filter {
-            writer.write_all(format!("\n</sheetData>\n<autoFilter ref=\"{}\"/>\n", auto_filter.to_string()).as_bytes())
+            writer.write_all(
+                format!(
+                    "\n</sheetData>\n<autoFilter ref=\"{}\"/>\n",
+                    auto_filter.to_string()
+                )
+                .as_bytes(),
+            )
         } else {
             writer.write_all(b"\n</sheetData>\n")
         }
@@ -474,7 +554,7 @@ impl<'a, 'b> SheetWriter<'a, 'b> {
 
     pub fn append_row(&mut self, row: Row) -> Result<()> {
         self.sheet
-            .write_row(self.writer, row.replace_strings(&mut self.shared_strings))
+            .write_row(self.writer, row.replace_strings(self.shared_strings))
     }
 
     pub fn append_blank_rows(&mut self, rows: usize) {
@@ -542,9 +622,9 @@ mod chrono_tests {
         const EXPECTED: f64 = 41223.63725694444;
         let cell = NaiveDate::from_ymd(2012, 11, 10)
             .and_hms(15, 17, 39)
-            .to_cell_value();
+            .to_cell_data();
 
-        match cell {
+        match cell.value {
             CellValue::Datetime(n) if n == EXPECTED => {}
             CellValue::Datetime(n) => panic!(
                 "invalid chrono::NaiveDateTime conversion to CellValue. {} is expected, found {}",
@@ -557,9 +637,9 @@ mod chrono_tests {
     #[test]
     fn chrono_date() {
         const EXPECTED: f64 = 41223.;
-        let cell = NaiveDate::from_ymd(2012, 11, 10).to_cell_value();
+        let cell = NaiveDate::from_ymd(2012, 11, 10).to_cell_data();
 
-        match cell {
+        match cell.value {
             CellValue::Date(n) if n == EXPECTED => {}
             CellValue::Date(n) => panic!(
                 "invalid chrono::NaiveDate conversion to CellValue. {} is expected, found {}",

--- a/src/workbook.rs
+++ b/src/workbook.rs
@@ -1,7 +1,12 @@
-use std::{borrow::Borrow, fs::File};
+use std::collections::BTreeMap;
 use std::io::*;
 use std::path::*;
-use std::collections::HashMap;
+use std::{borrow::Borrow, fs::File};
+
+use crate::Border;
+use crate::Fill;
+use crate::Font;
+use crate::{NumberFormat, XfFormat};
 
 use super::{escape_xml, Sheet, SheetWriter};
 
@@ -21,9 +26,71 @@ fn path_format(path: &std::path::Path) -> String {
 
             buf.push_str(s.to_string_lossy().borrow());
         }
-        
+
         buf
     })
+}
+
+pub enum BorderStyle {
+    None,
+    Thin,
+    Medium,
+    Dashed,
+    Dotted,
+    Thick,
+    Double,
+    Hair,
+    MediumDashed,
+    DashDot,
+    MediumDashDot,
+    DashDotDot,
+    MediumDashDotDot,
+    SlantDashDot,
+}
+impl BorderStyle {
+    pub fn xml(&self) -> String {
+        format!(
+            "style=\"{}\"",
+            match self {
+                BorderStyle::None => "none",
+                BorderStyle::Thin => "thin",
+                BorderStyle::Medium => "medium",
+                BorderStyle::Dashed => "dashed",
+                BorderStyle::Dotted => "dotted",
+                BorderStyle::Thick => "thick",
+                BorderStyle::Double => "double",
+                BorderStyle::Hair => "hair",
+                BorderStyle::MediumDashed => "mediumDashed",
+                BorderStyle::DashDot => "dashDot",
+                BorderStyle::MediumDashDot => "mediumDashDot",
+                BorderStyle::DashDotDot => "dashDotDot",
+                BorderStyle::MediumDashDotDot => "mediumDashDotDot",
+                BorderStyle::SlantDashDot => "slantDashDot",
+            }
+        )
+    }
+}
+
+#[derive(Default)]
+pub struct BorderFormat {
+    pub top: Option<(BorderStyle, Color)>,
+    pub right: Option<(BorderStyle, Color)>,
+    pub bottom: Option<(BorderStyle, Color)>,
+    pub left: Option<(BorderStyle, Color)>,
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+pub enum Color {
+    Theme(u16),
+    Argb(u32),
+}
+impl Color {
+    fn xml(&self) -> String {
+        match self {
+            Color::Theme(theme) => format!("theme=\"{theme}\""),
+            Color::Argb(rgb) => format!("rgb=\"{rgb:0>8X}\""),
+        }
+    }
 }
 
 #[derive(Default)]
@@ -35,44 +102,77 @@ pub struct Workbook {
     sheets: Vec<SheetRef>,
     calc_chain: Vec<(String, usize)>,
     saved: bool,
-    cell_formats: CellFormats
+    cell_formats: CellFormats,
 }
+
+pub const BASE_NUM_FMT_CUSTOM: u16 = 165;
+pub const BASE_FILL: u16 = 2;
+pub const BASE_BORDER: u16 = 1;
 
 #[derive(Default)]
 struct CellFormats {
-    base_cust_id: u16,
-    pub num_fmts: HashMap<u16,String>,
-    pub cell_xfs: Vec<CellXf>
+    pub num_fmts: BTreeMap<u16, String>,
+    pub fills: Vec<(Color, Color)>,
+    pub borders: Vec<BorderFormat>,
+    pub cell_xfs: Vec<CellXf>,
 }
 
 impl CellFormats {
     pub fn new() -> CellFormats {
-        let base_cust_id = 165;
-        let mut fmts = vec![];
-        // Default cell formats
-        fmts.push(CellXf {num_fmt_id: 0, font_id: 0, fill_id: 0, border_id: 0, xf_id: 0, apply_num_fmt: 1});
-        fmts.push(CellXf {num_fmt_id: 14, font_id: 0, fill_id: 0, border_id: 0, xf_id: 0, apply_num_fmt: 1});
-        fmts.push(CellXf {num_fmt_id: 22, font_id: 0, fill_id: 0, border_id: 0, xf_id: 0, apply_num_fmt: 1});
-        CellFormats {base_cust_id, num_fmts: HashMap::new(), cell_xfs: fmts}
+        let cell_xfs = vec![
+            CellXf {
+                num_fmt: Some(NumberFormat(0)),
+                ..Default::default()
+            },
+            CellXf {
+                num_fmt: Some(NumberFormat(14)),
+                ..Default::default()
+            },
+            CellXf {
+                num_fmt: Some(NumberFormat(22)),
+                ..Default::default()
+            },
+
+        ];
+        CellFormats {
+            num_fmts: BTreeMap::new(),
+            fills: Vec::new(),
+            borders: Vec::new(),
+            cell_xfs,
+        }
     }
 
-    pub fn add_cust_number_format(&mut self, pattern: String) -> u16 {
-        let new_id = self.base_cust_id + self.num_fmts.len() as u16;
+    pub fn add_fill(&mut self, fg_color: Color, bg_color: Color) -> Fill {
+        let result = BASE_FILL + self.fills.len() as u16;
+        self.fills.push((fg_color, bg_color));
+        Fill(result)
+    }
+
+    pub fn add_border(&mut self, border_format: BorderFormat) -> Border {
+        let result = BASE_BORDER + self.borders.len() as u16;
+        self.borders.push(border_format);
+        Border(result)
+    }
+
+    pub fn add_number_format(&mut self, pattern: String) -> NumberFormat {
+        let new_id = BASE_NUM_FMT_CUSTOM + self.num_fmts.len() as u16;
         self.num_fmts.insert(new_id, pattern);
+        NumberFormat(new_id)
+    }
+
+    pub fn add_cell_xf(&mut self, cell_xf: CellXf) -> XfFormat {
         let result = self.cell_xfs.len() as u16;
-        self.cell_xfs.push(CellXf{num_fmt_id: new_id, font_id: 0, fill_id: 0, border_id:  0, xf_id: 0, apply_num_fmt: 1});
-        result
+        self.cell_xfs.push(cell_xf);
+        XfFormat(result)
     }
 }
 
 #[derive(Default, Clone)]
-struct CellXf {
-    pub num_fmt_id: u16,
-    pub font_id: u16,
-    pub fill_id: u16,
-    pub border_id: u16,
-    pub xf_id: u16,
-    pub apply_num_fmt: u16
+pub struct CellXf {
+    pub num_fmt: Option<NumberFormat>,
+    pub font: Option<Font>,
+    pub fill: Option<Fill>,
+    pub border: Option<Border>,
 }
 
 #[derive(Default, Clone)]
@@ -134,7 +234,7 @@ impl Workbook {
             sheets: Vec::new(),
             calc_chain: Vec::new(),
             saved: false,
-            cell_formats: CellFormats::new()
+            cell_formats: CellFormats::new(),
         }
     }
     /// Creates a workbook not using shared strings
@@ -147,7 +247,7 @@ impl Workbook {
             sheets: Vec::new(),
             calc_chain: Vec::new(),
             saved: false,
-            cell_formats: CellFormats::new()
+            cell_formats: CellFormats::new(),
         }
     }
 
@@ -160,7 +260,7 @@ impl Workbook {
             sheets: Vec::new(),
             calc_chain: Vec::new(),
             saved: false,
-            cell_formats: CellFormats::new()
+            cell_formats: CellFormats::new(),
         }
     }
 
@@ -211,8 +311,20 @@ impl Workbook {
         }
     }
 
-    pub fn add_cust_number_format(&mut self, format_str: String) -> u16 {
-        self.cell_formats.add_cust_number_format(format_str)
+    pub fn add_fill(&mut self, fg_color: Color, bg_color: Color) -> Fill {
+        self.cell_formats.add_fill(fg_color, bg_color)
+    }
+
+    pub fn add_border(&mut self, border_format: BorderFormat) -> Border {
+        self.cell_formats.add_border(border_format)
+    }
+
+    pub fn add_number_format(&mut self, format_str: String) -> NumberFormat {
+        self.cell_formats.add_number_format(format_str)
+    }
+
+    pub fn add_cell_xf(&mut self, cell_xf: CellXf) -> XfFormat {
+        self.cell_formats.add_cell_xf(cell_xf)
     }
 
     fn create_files(&mut self) -> Result<()> {
@@ -288,7 +400,7 @@ impl Workbook {
             data: writer,
         });
         root.pop();
-        
+
         root.push("calcChain.xml");
         let mut writer = Vec::new();
         self.create_calc_chain(&mut writer)?;
@@ -362,10 +474,7 @@ impl Workbook {
 <calcChain xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">"#;
         writer.write_all(xml)?;
         for x in &self.calc_chain {
-            let wb = format!(
-                "<c r=\"{}\" i=\"{}\"/>",
-                x.0, x.1
-            );
+            let wb = format!("<c r=\"{}\" i=\"{}\"/>", x.0, x.1);
             writer.write_all(wb.as_bytes())?;
         }
         let tail = br#"</calcChain>"#;
@@ -473,20 +582,28 @@ impl Workbook {
             xmlns:vt="http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes">
 "#;
         writer.write_all(xml)?;
-        if self.cell_formats.num_fmts.len() > 0 {
-            let num_fmts = format!("    <numFmts count=\"{}\">", self.cell_formats.num_fmts.len());
+        if !self.cell_formats.num_fmts.is_empty() {
+            let num_fmts = format!(
+                "    <numFmts count=\"{}\">",
+                self.cell_formats.num_fmts.len()
+            );
             writer.write_all(num_fmts.as_bytes())?;
             // Sort the map for consistent XML format
             let mut fmts_sorted: Vec<(&u16, &String)> = self.cell_formats.num_fmts.iter().collect();
             fmts_sorted.sort_by_key(|item| item.0);
             for (fmt_id, value) in fmts_sorted {
-                let fmt = format!("\n        <numFmt numFmtId=\"{}\" formatCode=\"{}\"/>", fmt_id, escape_xml(value));
+                let fmt = format!(
+                    "\n        <numFmt numFmtId=\"{}\" formatCode=\"{}\"/>",
+                    fmt_id,
+                    escape_xml(value)
+                );
                 writer.write_all(fmt.as_bytes())?;
             }
             let fmt_tail = "\n    </numFmts>\n".as_bytes();
             writer.write_all(fmt_tail)?;
         }
-        let mid = br#"    <fonts count="1">
+        let mid = format!(
+            r#"    <fonts count="1">
         <font>
             <sz val="12"/>
             <color theme="1"/>
@@ -495,15 +612,34 @@ impl Workbook {
             <scheme val="minor"/>
         </font>
     </fonts>
-    <fills count="2">
+    <fills count="{}">
         <fill>
             <patternFill patternType="none"/>
         </fill>
         <fill>
             <patternFill patternType="gray125"/>
         </fill>
-    </fills>
-    <borders count="1">
+"#,
+            self.cell_formats.fills.len() as u16 + BASE_FILL
+        );
+        writer.write_all(mid.as_bytes())?;
+        for (fg, bg) in self.cell_formats.fills.iter() {
+            let fill = format!(
+                r#"        <fill>
+            <patternFill patternType="solid">
+                <fgColor {}/>
+                <bgColor {}/>
+            </patternFill>
+        </fill>
+"#,
+                fg.xml(),
+                bg.xml()
+            );
+            writer.write_all(fill.as_bytes())?;
+        }
+        let mid2 = format!(
+            r#"    </fills>
+    <borders count="{}">
         <border>
             <left/>
             <right/>
@@ -511,17 +647,65 @@ impl Workbook {
             <bottom/>
             <diagonal/>
         </border>
-    </borders>
+"#,
+            self.cell_formats.borders.len() as u16 + BASE_BORDER
+        );
+        writer.write_all(mid2.as_bytes())?;
+        for border in self.cell_formats.borders.iter() {
+            writer.write_all(b"        <border>\n")?;
+            let mappings = [
+                ("left", border.left.as_ref()),
+                ("right", border.right.as_ref()),
+                ("top", border.top.as_ref()),
+                ("bottom", border.bottom.as_ref()),
+            ];
+            for (side, border) in mappings {
+                if let Some((style, color)) = border {
+                    writeln!(writer, "            <{side} {}>", style.xml())?;
+                    writeln!(writer, "                <color {}/>", color.xml())?;
+                    writeln!(writer, "            </{side}>")?;
+                } else {
+                    writeln!(writer, "            <{side}/>")?;
+                }
+            }
+            writer.write_all(b"            <diagonal/>\n")?;
+            writer.write_all(b"        </border>\n")?;
+        }
+        let mid3 = br#"    </borders>
     <cellStyleXfs count="1">
         <xf numFmtId="0" fontId="0" fillId="0" borderId="0"/>
     </cellStyleXfs>"#;
-        writer.write_all(mid)?;
-        if self.cell_formats.cell_xfs.len() > 0 {
-            let cell_xfs_start = format!("\n    <cellXfs count=\"{}\">", self.cell_formats.cell_xfs.len());
+        writer.write_all(mid3)?;
+        if !self.cell_formats.cell_xfs.is_empty() {
+            let cell_xfs_start = format!(
+                "\n    <cellXfs count=\"{}\">",
+                self.cell_formats.cell_xfs.len()
+            );
             writer.write_all(cell_xfs_start.as_bytes())?;
             for xf in &self.cell_formats.cell_xfs {
-                let xf_entry = format!("\n        <xf numFmtId=\"{}\" fontId=\"{}\" fillId=\"{}\" borderId=\"{}\" xfId=\"{}\" applyNumberFormat=\"{}\"/>", xf.num_fmt_id, xf.font_id, xf.fill_id, xf.border_id, xf.xf_id, xf.apply_num_fmt);
-                writer.write_all(xf_entry.as_bytes())?;
+                let num_fmt_id = xf.num_fmt.unwrap_or(NumberFormat(0)).0;
+                let font_id = xf.font.unwrap_or(Font(0)).0;
+                let fill_id = xf.fill.unwrap_or(Fill(0)).0;
+                let border_id = xf.border.unwrap_or(Border(0)).0;
+                write!(writer, "\n        <xf")?;
+                write!(writer, " numFmtId=\"{num_fmt_id}\"")?;
+                write!(writer, " fontId=\"{font_id}\"")?;
+                write!(writer, " fillId=\"{fill_id}\"")?;
+                write!(writer, " borderId=\"{border_id}\"")?;
+                write!(writer, " xfId=\"0\"")?;
+                if num_fmt_id > 0 {
+                    write!(writer, " applyNumberFormat=\"1\"")?;
+                }
+                if font_id > 0 {
+                    write!(writer, " applyFont=\"1\"")?;
+                }
+                if fill_id > 0 {
+                    write!(writer, " applyFill=\"1\"")?;
+                }
+                if border_id > 0 {
+                    write!(writer, " applyBorder=\"1\"")?;
+                }
+                write!(writer, "/>")?;
             }
             let cell_xfs_end = "\n    </cellXfs>\n".as_bytes();
             writer.write_all(cell_xfs_end)?;

--- a/src/workbook.rs
+++ b/src/workbook.rs
@@ -31,6 +31,7 @@ fn path_format(path: &std::path::Path) -> String {
     })
 }
 
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum BorderStyle {
     None,
     Thin,
@@ -71,7 +72,7 @@ impl BorderStyle {
     }
 }
 
-#[derive(Default)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub struct BorderFormat {
     pub top: Option<(BorderStyle, Color)>,
     pub right: Option<(BorderStyle, Color)>,
@@ -79,7 +80,7 @@ pub struct BorderFormat {
     pub left: Option<(BorderStyle, Color)>,
 }
 
-#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum Color {
     Theme(u16),
     Argb(u32),

--- a/src/workbook.rs
+++ b/src/workbook.rs
@@ -72,7 +72,7 @@ impl BorderStyle {
     }
 }
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Default)]
 pub struct BorderFormat {
     pub top: Option<(BorderStyle, Color)>,
     pub right: Option<(BorderStyle, Color)>,

--- a/tests/creates_file_with_custom_number_format_and_checks_style.xml
+++ b/tests/creates_file_with_custom_number_format_and_checks_style.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+            xmlns:vt="http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes">
+    <numFmts count="3">
+        <numFmt numFmtId="165" formatCode="&quot;$&quot;#,##0.00"/>
+        <numFmt numFmtId="166" formatCode="#,##0.00&quot; KG&quot;"/>
+        <numFmt numFmtId="167" formatCode="#,##0.0&quot;&lt;&gt;&quot;"/>
+    </numFmts>
+    <fonts count="1">
+        <font>
+            <sz val="12"/>
+            <color theme="1"/>
+            <name val="Calibri"/>
+            <family val="2"/>
+            <scheme val="minor"/>
+        </font>
+    </fonts>
+    <fills count="2">
+        <fill>
+            <patternFill patternType="none"/>
+        </fill>
+        <fill>
+            <patternFill patternType="gray125"/>
+        </fill>
+    </fills>
+    <borders count="1">
+        <border>
+            <left/>
+            <right/>
+            <top/>
+            <bottom/>
+            <diagonal/>
+        </border>
+    </borders>
+    <cellStyleXfs count="1">
+        <xf numFmtId="0" fontId="0" fillId="0" borderId="0"/>
+    </cellStyleXfs>
+    <cellXfs count="6">
+        <xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0"/>
+        <xf numFmtId="14" fontId="0" fillId="0" borderId="0" xfId="0" applyNumberFormat="1"/>
+        <xf numFmtId="22" fontId="0" fillId="0" borderId="0" xfId="0" applyNumberFormat="1"/>
+        <xf numFmtId="165" fontId="0" fillId="0" borderId="0" xfId="0" applyNumberFormat="1"/>
+        <xf numFmtId="166" fontId="0" fillId="0" borderId="0" xfId="0" applyNumberFormat="1"/>
+        <xf numFmtId="167" fontId="0" fillId="0" borderId="0" xfId="0" applyNumberFormat="1"/>
+    </cellXfs>
+    <cellStyles count="1">
+        <cellStyle name="Normal" xfId="0" builtinId="0"/>
+    </cellStyles>
+    <dxfs count="0"/>
+    <tableStyles count="0" defaultTableStyle="TableStyleMedium9" defaultPivotStyle="PivotStyleMedium4"/>
+</styleSheet>

--- a/tests/default_style.xml
+++ b/tests/default_style.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+            xmlns:vt="http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes">
+    <fonts count="1">
+        <font>
+            <sz val="12"/>
+            <color theme="1"/>
+            <name val="Calibri"/>
+            <family val="2"/>
+            <scheme val="minor"/>
+        </font>
+    </fonts>
+    <fills count="2">
+        <fill>
+            <patternFill patternType="none"/>
+        </fill>
+        <fill>
+            <patternFill patternType="gray125"/>
+        </fill>
+    </fills>
+    <borders count="1">
+        <border>
+            <left/>
+            <right/>
+            <top/>
+            <bottom/>
+            <diagonal/>
+        </border>
+    </borders>
+    <cellStyleXfs count="1">
+        <xf numFmtId="0" fontId="0" fillId="0" borderId="0"/>
+    </cellStyleXfs>
+    <cellXfs count="3">
+        <xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0"/>
+        <xf numFmtId="14" fontId="0" fillId="0" borderId="0" xfId="0" applyNumberFormat="1"/>
+        <xf numFmtId="22" fontId="0" fillId="0" borderId="0" xfId="0" applyNumberFormat="1"/>
+    </cellXfs>
+    <cellStyles count="1">
+        <cellStyle name="Normal" xfId="0" builtinId="0"/>
+    </cellStyles>
+    <dxfs count="0"/>
+    <tableStyles count="0" defaultTableStyle="TableStyleMedium9" defaultPivotStyle="PivotStyleMedium4"/>
+</styleSheet>

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,7 +1,7 @@
 extern crate simple_excel_writer;
-use std::io::{Cursor, Read};
 use excel::*;
 use simple_excel_writer as excel;
+use std::io::{Cursor, Read};
 
 fn creates_and_saves_an_excel_sheet_driver(filename: Option<&str>) -> Option<Vec<u8>> {
     let mut wb = if let Some(name) = filename {
@@ -80,160 +80,130 @@ fn creates_and_saves_an_excel_sheet() {
     assert!(in_memory_test.is_some());
 }
 
-const DEFAULT_STYLE_XML: &str = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
-            xmlns:vt="http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes">
-    <fonts count="1">
-        <font>
-            <sz val="12"/>
-            <color theme="1"/>
-            <name val="Calibri"/>
-            <family val="2"/>
-            <scheme val="minor"/>
-        </font>
-    </fonts>
-    <fills count="2">
-        <fill>
-            <patternFill patternType="none"/>
-        </fill>
-        <fill>
-            <patternFill patternType="gray125"/>
-        </fill>
-    </fills>
-    <borders count="1">
-        <border>
-            <left/>
-            <right/>
-            <top/>
-            <bottom/>
-            <diagonal/>
-        </border>
-    </borders>
-    <cellStyleXfs count="1">
-        <xf numFmtId="0" fontId="0" fillId="0" borderId="0"/>
-    </cellStyleXfs>
-    <cellXfs count="3">
-        <xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0" applyNumberFormat="1"/>
-        <xf numFmtId="14" fontId="0" fillId="0" borderId="0" xfId="0" applyNumberFormat="1"/>
-        <xf numFmtId="22" fontId="0" fillId="0" borderId="0" xfId="0" applyNumberFormat="1"/>
-    </cellXfs>
-    <cellStyles count="1">
-        <cellStyle name="Normal" xfId="0" builtinId="0"/>
-    </cellStyles>
-    <dxfs count="0"/>
-    <tableStyles count="0" defaultTableStyle="TableStyleMedium9" defaultPivotStyle="PivotStyleMedium4"/>
-</styleSheet>"#;
+const DEFAULT_STYLE_XML: &str = include_str!("default_style.xml");
 
 #[test]
 fn creates_file_and_checks_default_style() {
     let mem_file = creates_and_saves_an_excel_sheet_driver(None).unwrap();
     let result = get_file_as_str_from_zip(&mem_file, "xl/styles.xml");
-    assert_eq!(DEFAULT_STYLE_XML.to_string(), result, "The style sheet should match!");
+    assert_eq!(
+        DEFAULT_STYLE_XML.to_string(),
+        result,
+        "The style sheet should match!"
+    );
 }
 
 #[test]
 fn creates_file_with_custom_number_format_and_checks_style() {
-    let expected_xml = r##"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
-            xmlns:vt="http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes">
-    <numFmts count="3">
-        <numFmt numFmtId="165" formatCode="&quot;$&quot;#,##0.00"/>
-        <numFmt numFmtId="166" formatCode="#,##0.00&quot; KG&quot;"/>
-        <numFmt numFmtId="167" formatCode="#,##0.0&quot;&lt;&gt;&quot;"/>
-    </numFmts>
-    <fonts count="1">
-        <font>
-            <sz val="12"/>
-            <color theme="1"/>
-            <name val="Calibri"/>
-            <family val="2"/>
-            <scheme val="minor"/>
-        </font>
-    </fonts>
-    <fills count="2">
-        <fill>
-            <patternFill patternType="none"/>
-        </fill>
-        <fill>
-            <patternFill patternType="gray125"/>
-        </fill>
-    </fills>
-    <borders count="1">
-        <border>
-            <left/>
-            <right/>
-            <top/>
-            <bottom/>
-            <diagonal/>
-        </border>
-    </borders>
-    <cellStyleXfs count="1">
-        <xf numFmtId="0" fontId="0" fillId="0" borderId="0"/>
-    </cellStyleXfs>
-    <cellXfs count="6">
-        <xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0" applyNumberFormat="1"/>
-        <xf numFmtId="14" fontId="0" fillId="0" borderId="0" xfId="0" applyNumberFormat="1"/>
-        <xf numFmtId="22" fontId="0" fillId="0" borderId="0" xfId="0" applyNumberFormat="1"/>
-        <xf numFmtId="165" fontId="0" fillId="0" borderId="0" xfId="0" applyNumberFormat="1"/>
-        <xf numFmtId="166" fontId="0" fillId="0" borderId="0" xfId="0" applyNumberFormat="1"/>
-        <xf numFmtId="167" fontId="0" fillId="0" borderId="0" xfId="0" applyNumberFormat="1"/>
-    </cellXfs>
-    <cellStyles count="1">
-        <cellStyle name="Normal" xfId="0" builtinId="0"/>
-    </cellStyles>
-    <dxfs count="0"/>
-    <tableStyles count="0" defaultTableStyle="TableStyleMedium9" defaultPivotStyle="PivotStyleMedium4"/>
-</styleSheet>"##.to_string();
+    let expected_xml = include_str!("creates_file_with_custom_number_format_and_checks_style.xml");
     let mut wb = excel::Workbook::create_in_memory();
-    let dollar_idx = wb.add_cust_number_format("\"$\"#,##0.00".to_string());
-    let weight_idx = wb.add_cust_number_format("#,##0.00\" KG\"".to_string());
-    let diamond_idx = wb.add_cust_number_format("#,##0.0\"<>\"".to_string());
+    let dollar_idx = wb.add_number_format("\"$\"#,##0.00".to_string());
+    let dollar_fmt = wb.add_cell_xf(CellXf {
+        num_fmt: Some(dollar_idx),
+        ..Default::default()
+    });
+    let weight_idx = wb.add_number_format("#,##0.00\" KG\"".to_string());
+    let weight_fmt = wb.add_cell_xf(CellXf {
+        num_fmt: Some(weight_idx),
+        ..Default::default()
+    });
+    let diamond_idx = wb.add_number_format("#,##0.0\"<>\"".to_string());
+    let diamond_fmt = wb.add_cell_xf(CellXf {
+        num_fmt: Some(diamond_idx),
+        ..Default::default()
+    });
 
-    assert_eq!(dollar_idx, 3);
-    assert_eq!(weight_idx, 4);
-    assert_eq!(diamond_idx, 5);
+    assert_eq!(dollar_fmt.value(), 3);
+    assert_eq!(weight_fmt.value(), 4);
+    assert_eq!(diamond_fmt.value(), 5);
 
     let mut ws = wb.create_sheet("test_sheet");
     ws.add_column(Column { width: 20.0 });
     ws.add_column(Column { width: 20.0 });
     ws.add_column(Column { width: 20.0 });
     wb.write_sheet(&mut ws, |sw| {
-        sw.append_row(row!["Cost", "Weight", "Symbol"]).expect("Should append header!");
-        sw.append_row(row![(20.1, dollar_idx), (50.12, weight_idx), (700.0, diamond_idx)])
+        sw.append_row(row!["Cost", "Weight", "Symbol"])
+            .expect("Should append header!");
+        sw.append_row(row![
+            (20.1, dollar_fmt),
+            (50.12, weight_fmt),
+            (700.0, diamond_fmt)
+        ])
     })
     .expect("Write excel error!");
 
-    let mem_file = wb.close().expect("No error on workbook close!").expect("Should have file in memory!");
+    let mem_file = wb
+        .close()
+        .expect("No error on workbook close!")
+        .expect("Should have file in memory!");
     let result = get_file_as_str_from_zip(&mem_file, "xl/styles.xml");
     assert_eq!(expected_xml, result, "The style sheet should match!");
 
     let sheet1 = get_file_as_str_from_zip(&mem_file, "xl/worksheets/sheet1.xml");
-    assert!(sheet1.contains(format!("<c r=\"A2\" s=\"{}\"><v>20.1</v></c>", dollar_idx).as_str()), "First cell should reference the 3rd index of the cellXfs list");
-    assert!(sheet1.contains(format!("<c r=\"B2\" s=\"{}\"><v>50.12</v></c>", weight_idx).as_str()), "First cell should reference the 4th index of the cellXfs list");
-    assert!(sheet1.contains(format!("<c r=\"C2\" s=\"{}\"><v>700</v></c>", diamond_idx).as_str()), "First cell should reference the 5th (last) index of the cellXfs list");
+    assert!(
+        dbg!(&sheet1).contains(format!("<c r=\"A2\" s=\"{}\"><v>20.1</v></c>", 3).as_str()),
+        "First cell should reference the 3rd index of the cellXfs list"
+    );
+    assert!(
+        sheet1.contains(format!("<c r=\"B2\" s=\"{}\"><v>50.12</v></c>", 4).as_str()),
+        "First cell should reference the 4th index of the cellXfs list"
+    );
+    assert!(
+        sheet1.contains(format!("<c r=\"C2\" s=\"{}\"><v>700</v></c>", 5).as_str()),
+        "First cell should reference the 5th (last) index of the cellXfs list"
+    );
 }
 
 #[cfg(feature = "chrono")]
 #[test]
-fn chrono_check_default_style () {
+fn chrono_check_default_style() {
     let mut wb = excel::Workbook::create_in_memory();
     let mut ws = wb.create_sheet("test_sheet");
     ws.add_column(Column { width: 20.0 });
     ws.add_column(Column { width: 20.0 });
     ws.add_column(Column { width: 20.0 });
     wb.write_sheet(&mut ws, |sw| {
-        sw.append_row(row!["Date", "Datetime"]).expect("Should append header!");
-        sw.append_row(row![chrono::NaiveDate::from_ymd(2012, 11, 10), chrono::NaiveDate::from_ymd(2014, 9, 8).and_hms(21, 12, 44)])
+        sw.append_row(row!["Date", "Datetime"])
+            .expect("Should append header!");
+        sw.append_row(row![
+            chrono::NaiveDate::from_ymd(2012, 11, 10),
+            chrono::NaiveDate::from_ymd(2014, 9, 8).and_hms(21, 12, 44)
+        ])
     })
     .expect("Write excel error!");
 
-    let mem_file = wb.close().expect("No error on workbook close!").expect("Should have file in memory!");
+    let mem_file = wb
+        .close()
+        .expect("No error on workbook close!")
+        .expect("Should have file in memory!");
     let result = get_file_as_str_from_zip(&mem_file, "xl/styles.xml");
-    assert_eq!(DEFAULT_STYLE_XML.to_string(), result, "The style sheet should match!");
+    assert_eq!(
+        DEFAULT_STYLE_XML.to_string(),
+        result,
+        "The style sheet should match!"
+    );
 
     let sheet1 = get_file_as_str_from_zip(&mem_file, "xl/worksheets/sheet1.xml");
     let expected_date_format_idx = 1;
     let expected_datetime_format_idx = 2;
-    assert!(sheet1.contains(format!("<c r=\"A2\" s=\"{}\"><v>41223</v></c>", expected_date_format_idx).as_str()), "Date contains correct reference to date format");
-    assert!(sheet1.contains(format!("<c r=\"B2\" s=\"{}\"><v>41890.88384259259</v></c>", expected_datetime_format_idx).as_str()), "Date contains correct reference to date format");
+    assert!(
+        sheet1.contains(
+            format!(
+                "<c r=\"A2\" s=\"{}\"><v>41223</v></c>",
+                expected_date_format_idx
+            )
+            .as_str()
+        ),
+        "Date contains correct reference to date format"
+    );
+    assert!(
+        sheet1.contains(
+            format!(
+                "<c r=\"B2\" s=\"{}\"><v>41890.88384259259</v></c>",
+                expected_datetime_format_idx
+            )
+            .as_str()
+        ),
+        "Date contains correct reference to date format"
+    );
 }

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -8,13 +8,22 @@ fn adds_autofilter_to_worksheet() {
     let mut ws = wb.create_sheet("test_sheet");
 
     ws.add_auto_filter(0, 0, 0, 0);
-    assert!(ws.auto_filter.is_none(), "An invalid range should not create an autofilter");
+    assert!(
+        ws.auto_filter.is_none(),
+        "An invalid range should not create an autofilter"
+    );
 
     ws.add_auto_filter(1, 3, 3, 2);
-    assert!(ws.auto_filter.is_none(), "An invalid range should not create an autofilter");
+    assert!(
+        ws.auto_filter.is_none(),
+        "An invalid range should not create an autofilter"
+    );
 
     ws.add_auto_filter(24, 3, 1, 2);
-    assert!(ws.auto_filter.is_none(), "An invalid range should not create an autofilter");
+    assert!(
+        ws.auto_filter.is_none(),
+        "An invalid range should not create an autofilter"
+    );
 
     ws.add_auto_filter(1, 1, 1, 1);
     assert!(ws.auto_filter.is_some(), "No autofilter was created!");


### PR DESCRIPTION
This is a significantly breaking change, and would require a version bump.

The basic idea is to have an `XfFormat` attached to a cells data, instead of a `NumberFormat`. This change is breaking, as where before people could create a number format and place that on their cell directly, they now have to make a number format, attach that number format to an xf format, and then put that xf format on their cell.

This currently only adds borders and fills, but it adds clear room in the API to add other xf formats in future.